### PR TITLE
libfwup: Fix type of argument in efidp_format_device_path function

### DIFF
--- a/linux/libfwup.c
+++ b/linux/libfwup.c
@@ -2102,7 +2102,7 @@ fwup_print_update_info(void)
 		efi_guid_t *guid = &info->guid;
 		char *id_guid = NULL;
 		ssize_t dp_sz;
-		char *path;
+		unsigned char *path;
 
 		rc = efi_guid_to_id_guid(guid, &id_guid);
 		if (rc < 0)


### PR DESCRIPTION
Currently, the efivar have changed the type of 'path' argument in
function 'efidp_format_device_path' from 'char *' to 'unsigned char *'.
It caused failure in compiling. This patch is intended to fix it.

Signed-off-by: Nhi Pham <npham@amperecomputing.com>